### PR TITLE
feat(Ssp_geniee Bid Adapter): Add support for GPID and pbadslot

### DIFF
--- a/modules/ssp_genieeBidAdapter.js
+++ b/modules/ssp_genieeBidAdapter.js
@@ -129,6 +129,8 @@ function hasParamsNotBlankString(params, key) {
  * @see https://docs.prebid.org/dev-docs/bidder-adaptor.html#location-and-referrers
  */
 function makeCommonRequestData(bid, geparameter, refererInfo) {
+  const gpid = utils.deepAccess(bid, 'ortb2Imp.ext.gpid') || utils.deepAccess(bid, 'ortb2Imp.ext.data.pbadslot');
+
   const data = {
     zoneid: bid.params.zoneId,
     cb: Math.floor(Math.random() * 99999999999),
@@ -145,6 +147,7 @@ function makeCommonRequestData(bid, geparameter, refererInfo) {
     tpaf: 1,
     cks: 1,
     ib: 0,
+    ...(gpid ? { gpid } : {}),
   };
 
   try {

--- a/test/spec/modules/ssp_genieeBidAdapter_spec.js
+++ b/test/spec/modules/ssp_genieeBidAdapter_spec.js
@@ -367,6 +367,59 @@ describe('ssp_genieeBidAdapter', function () {
         const request = spec.buildRequests([{...BANNER_BID, userId: {imuid}}]);
         expect(String(request[0].data.extuid)).to.have.string(`${`im:${imuid}`}`);
       });
+
+      it('should include gpid when ortb2Imp.ext.gpid exists', function () {
+        const gpid = '/123/abc';
+        const bidWithGpid = {
+          ...BANNER_BID,
+          ortb2Imp: {
+            ext: {
+              gpid: gpid
+            }
+          }
+        };
+        const request = spec.buildRequests([bidWithGpid]);
+        expect(String(request[0].data.gpid)).to.have.string(gpid);
+      });
+
+      it('should include gpid when ortb2Imp.ext.data.pbadslot exists', function () {
+        const pbadslot = '/123/abc';
+        const bidWithPbadslot = {
+          ...BANNER_BID,
+          ortb2Imp: {
+            ext: {
+              data: {
+                pbadslot: pbadslot
+              }
+            }
+          }
+        };
+        const request = spec.buildRequests([bidWithPbadslot]);
+        expect(String(request[0].data.gpid)).to.have.string(pbadslot);
+      });
+
+      it('should prioritize ortb2Imp.ext.gpid over ortb2Imp.ext.data.pbadslot', function () {
+        const gpid = '/123/abc';
+        const pbadslot = '/456/def';
+        const bidWithBoth = {
+          ...BANNER_BID,
+          ortb2Imp: {
+            ext: {
+              gpid: gpid,
+              data: {
+                pbadslot: pbadslot
+              }
+            }
+          }
+        };
+        const request = spec.buildRequests([bidWithBoth]);
+        expect(String(request[0].data.gpid)).to.have.string(gpid);
+      });
+
+      it('should not include gpid when neither ortb2Imp.ext.gpid nor ortb2Imp.ext.data.pbadslot exists', function () {
+        const request = spec.buildRequests([BANNER_BID]);
+        expect(request[0].data).to.not.have.property('gpid');
+      });
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

- Add support for GPID (Global Placement ID) from ortb2Imp.ext.gpid
- Add fallback support for ortb2Imp.ext.data.pbadslot
- Include gpid parameter in request when GPID exists
- Add test cases to verify GPID, pbadslot, and priority behavior

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
