### PR TITLE
Aladdin Bidder ID5 Compatible Adapter

### DIFF
--- a/modules/ssp_genieeBidAdapter.js
+++ b/modules/ssp_genieeBidAdapter.js
@@ -226,6 +226,7 @@ function makeCommonRequestData(bid, geparameter, refererInfo) {
     }
   }
 
+  // imuid, id5
   const id5 = utils.deepAccess(bid, 'userId.id5id.uid');
   const imuId = utils.deepAccess(bid, 'userId.imuid');
   const extuidQuery = buildExtuidQuery({id5, imuId});

--- a/modules/ssp_genieeBidAdapter.js
+++ b/modules/ssp_genieeBidAdapter.js
@@ -124,6 +124,17 @@ function hasParamsNotBlankString(params, key) {
   );
 }
 
+export const buildExtuidQuery = ({id5, imuId}) => {
+  const params = [
+    ...(id5 ? [`id5:${id5}`] : []),
+    ...(imuId ? [`im:${imuId}`] : []),
+  ];
+
+  const queryString = params.join('\t');
+  if (!queryString) return null;
+  return queryString;
+}
+
 /**
  * making request data be used commonly banner and native
  * @see https://docs.prebid.org/dev-docs/bidder-adaptor.html#location-and-referrers
@@ -215,9 +226,10 @@ function makeCommonRequestData(bid, geparameter, refererInfo) {
     }
   }
 
-  // imuid
-  const imuidQuery = getImuidAsQueryParameter(bid);
-  if (imuidQuery) data.extuid = imuidQuery;
+  const id5 = utils.deepAccess(bid, 'userId.id5id.uid');
+  const imuId = utils.deepAccess(bid, 'userId.imuid');
+  const extuidQuery = buildExtuidQuery({id5, imuId});
+  if (extuidQuery) data.extuid = extuidQuery;
 
   // makeUAQuery
   // To avoid double encoding, not using encodeURIComponent here
@@ -309,14 +321,6 @@ function makeChangeHeightEventMarkup(request) {
  */
 function makeBidResponseAd(innerHTML) {
   return '<body marginwidth="0" marginheight="0">' + innerHTML + '</body>';
-}
-
-/**
- * return imuid strings as query parameters
- */
-function getImuidAsQueryParameter(bid) {
-  const imuid = utils.deepAccess(bid, 'userId.imuid');
-  return imuid ? 'im:' + imuid : ''; // To avoid double encoding, not using encodeURIComponent here
 }
 
 function getUserAgent() {

--- a/test/spec/modules/ssp_genieeBidAdapter_spec.js
+++ b/test/spec/modules/ssp_genieeBidAdapter_spec.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import {
   spec,
   BANNER_ENDPOINT,
+  buildExtuidQuery,
 } from 'modules/ssp_genieeBidAdapter.js';
 import { config } from 'src/config.js';
 

--- a/test/spec/modules/ssp_genieeBidAdapter_spec.js
+++ b/test/spec/modules/ssp_genieeBidAdapter_spec.js
@@ -352,7 +352,7 @@ describe('ssp_genieeBidAdapter', function () {
         expect(request[0].data).to.not.have.property('extuid');
       });
 
-      it('should include an extuid query when bid.userId.imuid exists', function () {
+      it('should include only imuid in extuid query when only imuid exists', function () {
         const imuid = 'b.a4ad1d3eeb51e600';
         const request = spec.buildRequests([{...BANNER_BID, userId: {imuid}}]);
         expect(request[0].data.extuid).to.deep.equal(`im:${imuid}`);

--- a/test/spec/modules/ssp_genieeBidAdapter_spec.js
+++ b/test/spec/modules/ssp_genieeBidAdapter_spec.js
@@ -359,6 +359,24 @@ describe('ssp_genieeBidAdapter', function () {
         expect(request[0].data.extuid).to.deep.equal(`im:${imuid}`);
       });
 
+      it('should include only id5id in extuid query when only id5id exists', function () {
+        const id5id = 'id5id';
+        const request = spec.buildRequests([{...BANNER_BID, userId: {id5id: {uid: id5id}}}]);
+        expect(request[0].data.extuid).to.deep.equal(`id5:${id5id}`);
+      });
+
+      it('should include id5id and imuid in extuid query when id5id and imuid exists', function () {
+        const imuid = 'b.a4ad1d3eeb51e600';
+        const id5id = 'id5id';
+        const request = spec.buildRequests([{...BANNER_BID, userId: {id5id: {uid: id5id}, imuid: imuid}}]);
+        expect(request[0].data.extuid).to.deep.equal(`id5:${id5id}\tim:${imuid}`);
+      });
+
+      it('should not include the extuid query when both id5 and imuid are missing', function () {
+        const request = spec.buildRequests([BANNER_BID]);
+        expect(request[0].data).to.not.have.property('extuid');
+      });
+
       describe('buildExtuidQuery', function() {
         it('should return tab-separated string when both id5 and imuId exist', function() {
           const result = buildExtuidQuery({ id5: 'test_id5', imuId: 'test_imu' });

--- a/test/spec/modules/ssp_genieeBidAdapter_spec.js
+++ b/test/spec/modules/ssp_genieeBidAdapter_spec.js
@@ -348,11 +348,6 @@ describe('ssp_genieeBidAdapter', function () {
         expect(request[0].data.apid).to.deep.equal(bundle);
       });
 
-      it('should not include the extuid query when bid.userId.imuid does not exist', function () {
-        const request = spec.buildRequests([BANNER_BID]);
-        expect(request[0].data).to.not.have.property('extuid');
-      });
-
       it('should include only imuid in extuid query when only imuid exists', function () {
         const imuid = 'b.a4ad1d3eeb51e600';
         const request = spec.buildRequests([{...BANNER_BID, userId: {imuid}}]);

--- a/test/spec/modules/ssp_genieeBidAdapter_spec.js
+++ b/test/spec/modules/ssp_genieeBidAdapter_spec.js
@@ -358,6 +358,28 @@ describe('ssp_genieeBidAdapter', function () {
         expect(request[0].data.extuid).to.deep.equal(`im:${imuid}`);
       });
 
+      describe('buildExtuidQuery', function() {
+        it('should return tab-separated string when both id5 and imuId exist', function() {
+          const result = buildExtuidQuery({ id5: 'test_id5', imuId: 'test_imu' });
+          expect(result).to.equal('id5:test_id5\tim:test_imu');
+        });
+
+        it('should return only id5 when imuId is missing', function() {
+          const result = buildExtuidQuery({ id5: 'test_id5', imuId: null });
+          expect(result).to.equal('id5:test_id5');
+        });
+
+        it('should return only imuId when id5 is missing', function() {
+          const result = buildExtuidQuery({ id5: null, imuId: 'test_imu' });
+          expect(result).to.equal('im:test_imu');
+        });
+
+        it('should return null when both id5 and imuId are missing', function() {
+          const result = buildExtuidQuery({ id5: null, imuId: null });
+          expect(result).to.be.null;
+        });
+      });
+
       it('should include gpid when ortb2Imp.ext.gpid exists', function () {
         const gpid = '/123/abc';
         const bidWithGpid = {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->

Added support for including ID5 in the etuid query parameter.


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
