### PR TITLE
[CARPET-5190] Bid Adapter: Fix the default value of the ib parameter

### DIFF
--- a/modules/ssp_genieeBidAdapter.js
+++ b/modules/ssp_genieeBidAdapter.js
@@ -158,7 +158,6 @@ function makeCommonRequestData(bid, geparameter, refererInfo) {
     ua: navigator.userAgent,
     tpaf: 1,
     cks: 1,
-    ib: (bid.params.hasOwnProperty('invalidImpBeacon') && bid.params.invalidImpBeacon) ? 0 : 1,
     ...(gpid ? { gpid } : {}),
   };
 

--- a/modules/ssp_genieeBidAdapter.js
+++ b/modules/ssp_genieeBidAdapter.js
@@ -158,7 +158,7 @@ function makeCommonRequestData(bid, geparameter, refererInfo) {
     ua: navigator.userAgent,
     tpaf: 1,
     cks: 1,
-    ib: 0,
+    ib: (bid.params.hasOwnProperty('invalidImpBeacon') && bid.params.invalidImpBeacon) ? 0 : 1,
     ...(gpid ? { gpid } : {}),
   };
 

--- a/test/spec/modules/ssp_genieeBidAdapter_spec.js
+++ b/test/spec/modules/ssp_genieeBidAdapter_spec.js
@@ -186,26 +186,6 @@ describe('ssp_genieeBidAdapter', function () {
         expect(request[1].data.cur).to.deep.equal('USD');
       });
 
-      it('should makes invalidImpBeacon the value of params.invalidImpBeacon when params.invalidImpBeacon exists (in current version, this parameter is not necessary and ib is always `0`)', function () {
-        const request = spec.buildRequests([
-          {
-            ...BANNER_BID,
-            params: { ...BANNER_BID.params, invalidImpBeacon: true },
-          },
-          {
-            ...BANNER_BID,
-            params: { ...BANNER_BID.params, invalidImpBeacon: false },
-          },
-          {
-            ...BANNER_BID,
-            params: { ...BANNER_BID.params },
-          },
-        ]);
-        expect(request[0].data.ib).to.deep.equal(0);
-        expect(request[1].data.ib).to.deep.equal(1);
-        expect(request[2].data.ib).to.deep.equal(1);
-      });
-
       it('should not sets the value of the adtk query when geparams.lat does not exist', function () {
         const request = spec.buildRequests([BANNER_BID]);
         expect(request[0].data).to.not.have.property('adtk');

--- a/test/spec/modules/ssp_genieeBidAdapter_spec.js
+++ b/test/spec/modules/ssp_genieeBidAdapter_spec.js
@@ -202,8 +202,8 @@ describe('ssp_genieeBidAdapter', function () {
           },
         ]);
         expect(request[0].data.ib).to.deep.equal(0);
-        expect(request[1].data.ib).to.deep.equal(0);
-        expect(request[2].data.ib).to.deep.equal(0);
+        expect(request[1].data.ib).to.deep.equal(1);
+        expect(request[2].data.ib).to.deep.equal(1);
       });
 
       it('should not sets the value of the adtk query when geparams.lat does not exist', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
remove `ib: 0`

Generated file prebid.js : `$gulp serve-and-test --file ./modules/ssp_genieeBidAdapter.js`
```
$diff prebid_old.js prebid_new.js
189051d189050
<     ib: 0,
```
## Other information
relate issue: https://geniee.atlassian.net/browse/CARPET-5183
https://gitlab.geniee.jp/ssp/carpet/-/merge_requests/1626/

## Unit test
```
$gulp test --file "test/spec/modules/ssp_genieeBidAdapter_spec.js" --nolint

[13:05:04] Using gulpfile ~/Documents/projects/Prebid.js/gulpfile.js
[13:05:04] Starting 'test'...
[13:05:04] Starting 'clean'...
[13:05:04] Finished 'clean' after 12 ms
[13:05:04] Starting 'lint'...
[13:05:04] Finished 'lint' after 870 μs
[13:05:04] Starting 'test-all-features-disabled'...
Starting chunk 1 of 1: test/spec/modules/ssp_genieeBidAdapter_spec.js

START:
Webpack bundling...
Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
asset commons.js 3.02 MiB [emitted] (name: commons) (id hint: commons)
asset runtime.js 14 KiB [emitted] (name: runtime)
asset ssp_genieeBidAdapter_spec.2754296226.js 472 bytes [emitted] (name: ssp_genieeBidAdapter_spec.2754296226)
asset pipeline_setup.186226126.js 436 bytes [emitted] (name: pipeline_setup.186226126)
asset hookSetup.295546910.js 434 bytes [emitted] (name: hookSetup.295546910)
asset test_deps.3757365138.js 427 bytes [emitted] (name: test_deps.3757365138)
asset dependencies.json 305 bytes [emitted]
Entrypoint test_deps.3757365138 3.04 MiB = runtime.js 14 KiB commons.js 3.02 MiB test_deps.3757365138.js 427 bytes
Entrypoint pipeline_setup.186226126 3.04 MiB = runtime.js 14 KiB commons.js 3.02 MiB pipeline_setup.186226126.js 436 bytes
Entrypoint ssp_genieeBidAdapter_spec.2754296226 3.04 MiB = runtime.js 14 KiB commons.js 3.02 MiB ssp_genieeBidAdapter_spec.2754296226.js 472 bytes
Entrypoint hookSetup.295546910 3.04 MiB = runtime.js 14 KiB commons.js 3.02 MiB hookSetup.295546910.js 434 bytes
webpack 5.94.0 compiled successfully in 3700 ms
18 06 2025 13:05:12.675:INFO [karma-server]: Karma v6.4.3 server started at http://localhost:9877/
18 06 2025 13:05:12.677:INFO [launcher]: Launching browsers ChromeHeadless with concurrency 5
18 06 2025 13:05:12.693:INFO [launcher]: Starting browser ChromeHeadless
18 06 2025 13:05:14.491:INFO [Chrome Headless 137.0.0.0 (Mac OS 10.15.7)]: Connected on socket 8d4Ju8s17AvisGPoAAAB with id 54396986

Finished in 0.351 secs / 0.314 secs @ 13:05:15 GMT+0700 (Indochina Time)

SUMMARY:
✔ 55 tests completed
Chunk 1 of 1: done

[13:05:15] Finished 'test-all-features-disabled' after 11 s
[13:05:15] Starting 'test-only'...
Starting chunk 1 of 1: test/spec/modules/ssp_genieeBidAdapter_spec.js

START:
Webpack bundling...
Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
asset commons.js 3.03 MiB [emitted] (name: commons) (id hint: commons)
asset runtime.js 14 KiB [emitted] (name: runtime)
asset ssp_genieeBidAdapter_spec.2754296226.js 472 bytes [emitted] (name: ssp_genieeBidAdapter_spec.2754296226)
asset pipeline_setup.186226126.js 436 bytes [emitted] (name: pipeline_setup.186226126)
asset hookSetup.295546910.js 434 bytes [emitted] (name: hookSetup.295546910)
asset test_deps.3757365138.js 427 bytes [emitted] (name: test_deps.3757365138)
asset dependencies.json 305 bytes [emitted]
Entrypoint test_deps.3757365138 3.05 MiB = runtime.js 14 KiB commons.js 3.03 MiB test_deps.3757365138.js 427 bytes
Entrypoint pipeline_setup.186226126 3.05 MiB = runtime.js 14 KiB commons.js 3.03 MiB pipeline_setup.186226126.js 436 bytes
Entrypoint ssp_genieeBidAdapter_spec.2754296226 3.05 MiB = runtime.js 14 KiB commons.js 3.03 MiB ssp_genieeBidAdapter_spec.2754296226.js 472 bytes
Entrypoint hookSetup.295546910 3.05 MiB = runtime.js 14 KiB commons.js 3.03 MiB hookSetup.295546910.js 434 bytes
webpack 5.94.0 compiled successfully in 3099 ms
18 06 2025 13:05:23.911:INFO [karma-server]: Karma v6.4.3 server started at http://localhost:9877/
18 06 2025 13:05:23.914:INFO [launcher]: Launching browsers ChromeHeadless with concurrency 5
18 06 2025 13:05:23.928:INFO [launcher]: Starting browser ChromeHeadless
18 06 2025 13:05:25.640:INFO [Chrome Headless 137.0.0.0 (Mac OS 10.15.7)]: Connected on socket jw-Z9jMezMklG5fEAAAB with id 83418411

Finished in 0.239 secs / 0.214 secs @ 13:05:26 GMT+0700 (Indochina Time)

SUMMARY:
✔ 55 tests completed
Chunk 1 of 1: done

[13:05:26] Finished 'test-only' after 11 s
[13:05:26] Finished 'test' after 22 s

```
