### PR TITLE
[CARPET-5746] Add param title to JSK endpoint

### DIFF
--- a/modules/ssp_genieeBidAdapter.js
+++ b/modules/ssp_genieeBidAdapter.js
@@ -161,6 +161,11 @@ function makeCommonRequestData(bid, geparameter, refererInfo) {
     ...(gpid ? { gpid } : {}),
   };
 
+  const pageTitle = document.title;
+  if (pageTitle) {
+    data.title = encodeURIComponentIncludeSingleQuotation(pageTitle);
+  }
+
   try {
     if (window.self.toString() !== '[object Window]' || window.parent.toString() !== '[object Window]') {
       data.err = '1';

--- a/test/spec/modules/ssp_genieeBidAdapter_spec.js
+++ b/test/spec/modules/ssp_genieeBidAdapter_spec.js
@@ -132,6 +132,20 @@ describe('ssp_genieeBidAdapter', function () {
         expect(request[0].data.zoneid).to.deep.equal(BANNER_BID.params.zoneId);
       });
 
+      it('should set the title query to the encoded page title', function () {
+        const testTitle = "Test Page Title with 'special' & \"chars\"";
+        document.title = testTitle;
+        const request = spec.buildRequests([BANNER_BID]);
+        const expectedEncodedTitle = encodeURIComponent(testTitle).replace(/'/g, '%27');
+        expect(request[0].data.title).to.deep.equal(expectedEncodedTitle);
+      });
+
+      it('should not set the title query when the page title is empty', function () {
+        document.title = '';
+        const request = spec.buildRequests([BANNER_BID]);
+        expect(request[0].data).to.not.have.property('title');
+      });
+
       it('should sets the values for loc and referer queries when bidderRequest.refererInfo.referer has a value', function () {
         const referer = 'https://example.com/';
         const request = spec.buildRequests([BANNER_BID], {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
